### PR TITLE
Fix insecure content warning on HTTPS pages

### DIFF
--- a/css/widget.css
+++ b/css/widget.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,700);
+@import url(//fonts.googleapis.com/css?family=Roboto:400,700);
 
 .github-widget {
     box-sizing: border-box;


### PR DESCRIPTION
My HTTPS page was getting an insecure content warning stemming from this plugin. I removed the protocol from the font import link to allow the browser to select the correct protocol automatically.
