### PR TITLE
patch for chinese visitors

### DIFF
--- a/css/widget_chinese.css
+++ b/css/widget_chinese.css
@@ -1,0 +1,207 @@
+@import url(//fonts.lug.ustc.edu.cn/css?family=Roboto:400,700);
+
+.github-widget {
+    box-sizing: border-box;
+    font: 13px/1.4 Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
+    background-color: #fff;
+    border: 1px solid #d8d8d8 !important;
+    border-radius: 3px;
+    color: #333;
+}
+
+.github-widget a {
+    outline: 0;
+}
+
+.github-widget h2 {
+    font-size: 1em;
+    font-weight: bold;
+    margin: 1em 0 .1em;
+    padding: 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.05)
+}
+
+.github-widget-content {
+    padding: .323em;
+}
+
+.github-shadowed {
+    border-radius: 0.313em;
+    padding: 0.313em;
+    background: rgba(0, 0, 0, 0.03)
+}
+
+/* HEADER */
+
+.github-widget-header {
+    font-weight: bold;
+    background-color: #f5f5f5;
+    border-bottom: 1px solid #d8d8d8;
+    padding: 5px;
+    margin: 0;
+    margin-bottom: 6px;
+}
+
+.github-widget-company-logo {
+    display: inline-block;
+    vertical-align: middle;
+    height: 1.5em;
+    margin-right: .250em;
+    right: 0;
+}
+
+.github-widget-company-logo,
+.github-widget-header-text {
+    vertical-align: middle;
+}
+
+.github-widget-header-text,
+.github-widget-header-link {
+    font-weight: bold;
+    display: inline-block;
+    vertical-align: middle;
+    line-height: 1.5em;
+    color: rgb(57, 66, 78) !important;
+}
+
+.github-widget-header .separator {
+    margin: 0 .250em;
+}
+
+/* PROFILE */
+.github-profile-pic {
+    width: 25%;
+    display: inline-block;
+}
+
+.github-names {
+    display: inline-block;
+    vertical-align: top;
+    margin-left: 3%;
+}
+
+.github-name,
+.github-username {
+    display: block;
+}
+
+.github-name {
+    color: #444;
+    font-size: 1.15em;
+    margin: 0 0 0.1em !important;
+    font-weight: bold;
+}
+
+.github-username {
+    font-size: 1.15em;
+    font-weight: 300;
+    margin: 0.1em 0 !important;
+    color: #666;
+}
+
+.github-block:first-of-type {
+    border-top: 0;
+}
+
+.github-block:first-child {
+    padding: 0 0 8px 24px;
+}
+
+.github-block {
+    display: block;
+    padding: 10px 0 8px;
+    font-size: 14px;
+    border-top: 1px solid #eee;
+}
+
+.github-block.with-icons {
+
+    padding-left: 24px;
+}
+
+.github-block div {
+    margin: .2em 0;
+}
+
+.github-block a {
+    color: #4078c0;
+    text-decoration: none;
+}
+
+.github-block .octicon {
+    float: left;
+    width: 16px;
+    margin-left: -24px;
+    color: #ccc;
+    text-align: center;
+}
+
+.github-repo-name {
+    font-size: 80%;
+}
+
+.github-repos-toggle {
+    display: none;
+}
+
+.github-repos-toggle-la {
+    float: none !important;
+    margin: 0 !important;
+    cursor: pointer;
+}
+
+.github-repos-toggle:checked ~ .github-repos {
+    max-height: 150px;
+}
+
+.github-repos {
+    max-height: 0px;
+    overflow-x: hidden;
+    overflow-y: hidden;
+    -webkit-transition: all ease-in-out .2s;
+    -moz-transition: all ease-in-out .2s;
+    -ms-transition: all ease-in-out .2s;
+    -o-transition: all ease-in-out .2s;
+    transition: all ease-in-out .2s;
+}
+
+.github-repos:hover {
+    overflow-y: auto;
+}
+
+.github-avatarurl {
+    max-width: 36px;
+    border-radius: 3px;
+    margin-right: 7px;
+}
+
+.github-vcard-stats {
+    text-align: center;
+}
+
+.github-vcard-stat-count {
+    display: block;
+    font-size: 28px;
+    font-weight: bold;
+    line-height: 1;
+}
+
+.github-vcard-stat {
+    display: inline-block;
+    width: 45%;
+    font-size: 11px;
+    text-transform: capitalize;
+}
+
+.github-feed-entries {
+    max-height: 16em;
+    overflow: hidden;
+}
+.github-feed-entries:hover {
+    overflow-y: auto;
+}
+
+.github-feed-entry {
+    font-size: 90%;
+    margin-bottom: 0.1em;
+}

--- a/plugin.php
+++ b/plugin.php
@@ -132,7 +132,11 @@ class GitHub_Profile extends WP_Widget {
 
 	public function register_widget_styles() {
 		wp_enqueue_style( $this->widget_slug . '-octicons', plugins_url( 'css/octicons/octicons.css', __FILE__ ) );
-		wp_enqueue_style( $this->widget_slug . '-widget-styles', plugins_url( 'css/widget.css', __FILE__ ) );
+		if(get_option('google_fonts')) {
+			wp_enqueue_style( $this->widget_slug . '-widget-styles', plugins_url( 'css/widget_chinese.css', __FILE__ ) );
+		}else {
+			wp_enqueue_style( $this->widget_slug . '-widget-styles', plugins_url( 'css/widget.css', __FILE__ ) );
+		}
 	}
 
 	public function register_admin_scripts() {
@@ -141,4 +145,18 @@ class GitHub_Profile extends WP_Widget {
 
 }
 
+function github_profile_menu() {
+	if (isset($_POST["action"]) && $_POST["action"] == "saveconfiguration") {
+		update_option('google_fonts', $_POST["google_fonts"]);
+		echo '<div class="updated"><p><strong>Setting Updated！</strong></p></div>';
+	}
+	$google_fonts = get_option("google_fonts");
+	require 'views/menu.php';
+}
+
+function register_menu() {
+	add_submenu_page( 'options-general.php', 'GitHub Profile Widget', 'GitHub Profile Widget', 'manage_options', 'github_profile', 'github_profile_menu' );
+}
+
 add_action( 'widgets_init', create_function( '', 'return register_widget("GitHub_Profile");' ) );
+add_action( 'admin_menu', 'register_menu');

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === GitHub Profile Widget ===
-Contributors: hacdias, lsoares13
+Contributors: hacdias, lsoares13, wonderqs
 Tags: github, profile, widget, programming, development, open source, organization, git
 Requires at least: 3.0.1
 Tested up to: 4.4.1
@@ -20,6 +20,10 @@ This is a very simple plugin which gives you a widget to show your GitHub profil
 + Followers and following numbers;
 + Repositories and gists;
 + The organizations where you are included.
+
+**Patch (for Chinese visitors):**
+
+Because Google's service is not avaliable in China, the Google Fonts CDN always works bad in China. So the previous version of this plugin is not work well for Chinese visitors. This patched function provide an option to use Chinese CDN (http://fonts.lug.ustc.edu.cn/) instead of Google CDN (http://fonts.googleapis.com). You can dicide use Chinese CDN or not by choose the options on the new-added submenu under "Settings".
 
 **Advice: we are not affiliated with GitHub.**
 

--- a/views/menu.php
+++ b/views/menu.php
@@ -1,0 +1,21 @@
+<div class="wrap">
+	<form method="post">
+		<input type="hidden" name="action" value="saveconfiguration">
+		<h2>Github Profile Widget Setting</h2>
+		<table class="form-table">
+		<tr>
+			<th>Google Fonts Accelerate for Chinese Vistors</th>
+			<td>
+				<select name="google_fonts">
+				<option value="0">Google Original</option>
+				<option value="1"<?=$google_fonts==1?' selected="selected"':''?>>Chinese CDN</option>
+				</select>
+			</td>
+		</tr>
+		<tr>
+			<td><input type="submit" class="button button-primary" value="Save"></td>
+			<td></td>
+		</tr>
+		</table>
+	</form>
+</div>


### PR DESCRIPTION
This plugin can not work well in China, because it contains font file from Google's CDN, and Google's CDN is blocked in China. This branch is a patch to enable the plugin in China by offering an option to use Chinese CDN instead of Google's CDN. And users can decide to use this feature or not.
