### PR TITLE
fix: display organizations inline

### DIFF
--- a/css/widget.css
+++ b/css/widget.css
@@ -205,3 +205,8 @@
     font-size: 90%;
     margin-bottom: 0.1em;
 }
+
+.github-organizations a {
+    display: inline-block;
+    margin: 5px;
+}


### PR DESCRIPTION
Hi guys.

Just a fix to render organizations inline, like the Github site does. Please see how it looks like now here: http://cristianoliveira.com.br/#github-profile-3
